### PR TITLE
Added support for enabling/disabling backup policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,28 +7,28 @@ Truefoundry AWS EFS Module
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.4 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | 5.17.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | 5.49.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.17.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.49.0 |
 
 ## Modules
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_efs"></a> [efs](#module\_efs) | terraform-aws-modules/efs/aws | 1.1.1 |
+| <a name="module_efs"></a> [efs](#module\_efs) | terraform-aws-modules/efs/aws | 1.6.3 |
 | <a name="module_iam_assumable_role_admin"></a> [iam\_assumable\_role\_admin](#module\_iam\_assumable\_role\_admin) | terraform-aws-modules/iam/aws//modules/iam-assumable-role-with-oidc | 5.27.0 |
 
 ## Resources
 
 | Name | Type |
 |------|------|
-| [aws_iam_policy.efs](https://registry.terraform.io/providers/hashicorp/aws/5.17.0/docs/resources/iam_policy) | resource |
-| [aws_iam_policy_document.efs](https://registry.terraform.io/providers/hashicorp/aws/5.17.0/docs/data-sources/iam_policy_document) | data source |
-| [aws_subnet.selected](https://registry.terraform.io/providers/hashicorp/aws/5.17.0/docs/data-sources/subnet) | data source |
+| [aws_iam_policy.efs](https://registry.terraform.io/providers/hashicorp/aws/5.49.0/docs/resources/iam_policy) | resource |
+| [aws_iam_policy_document.efs](https://registry.terraform.io/providers/hashicorp/aws/5.49.0/docs/data-sources/iam_policy_document) | data source |
+| [aws_subnet.selected](https://registry.terraform.io/providers/hashicorp/aws/5.49.0/docs/data-sources/subnet) | data source |
 
 ## Inputs
 
@@ -38,6 +38,7 @@ Truefoundry AWS EFS Module
 | <a name="input_cluster_name"></a> [cluster\_name](#input\_cluster\_name) | EKS Cluster Name | `string` | n/a | yes |
 | <a name="input_cluster_oidc_issuer_url"></a> [cluster\_oidc\_issuer\_url](#input\_cluster\_oidc\_issuer\_url) | The oidc url of the eks cluster | `string` | n/a | yes |
 | <a name="input_efs_node_iam_role_arn"></a> [efs\_node\_iam\_role\_arn](#input\_efs\_node\_iam\_role\_arn) | The node IAM role ARN being used by the EFS daemonset | `string` | n/a | yes |
+| <a name="input_enable_backup_policy"></a> [enable\_backup\_policy](#input\_enable\_backup\_policy) | Enable EFS backup policy | `bool` | `true` | no |
 | <a name="input_k8s_service_account_name"></a> [k8s\_service\_account\_name](#input\_k8s\_service\_account\_name) | The k8s efs service account name | `string` | n/a | yes |
 | <a name="input_k8s_service_account_namespace"></a> [k8s\_service\_account\_namespace](#input\_k8s\_service\_account\_namespace) | The k8s efs namespace | `string` | n/a | yes |
 | <a name="input_performance_mode"></a> [performance\_mode](#input\_performance\_mode) | the performance mode for EFS | `string` | n/a | yes |

--- a/efs.tf
+++ b/efs.tf
@@ -64,7 +64,7 @@ data "aws_iam_policy_document" "efs" {
 
 module "efs" {
   source  = "terraform-aws-modules/efs/aws"
-  version = "1.1.1"
+  version = "1.6.3"
 
   name = "${var.cluster_name}-efs"
 
@@ -90,8 +90,9 @@ module "efs" {
       }]
     }
   ]
-  throughput_mode  = var.throughput_mode
-  performance_mode = var.performance_mode
+  throughput_mode      = var.throughput_mode
+  performance_mode     = var.performance_mode
+  enable_backup_policy = var.enable_backup_policy
   security_group_rules = {
     vpc = {
       # relying on the defaults provdied for EFS/NFS (2049/TCP + ingress)

--- a/variables.tf
+++ b/variables.tf
@@ -54,6 +54,12 @@ variable "performance_mode" {
   }
 }
 
+variable "enable_backup_policy" {
+  description = "Enable EFS backup policy"
+  type        = bool
+  default     = true
+}
+
 variable "cluster_oidc_issuer_url" {
   description = "The oidc url of the eks cluster"
   type        = string

--- a/versions.tf
+++ b/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "5.17.0"
+      version = "5.49.0"
     }
   }
 }


### PR DESCRIPTION
1. Bumped up version of aws provider to `5.49.0`
2. EFS module upgrade from `1.1.1` to `1.6.3`
3. Added support to enable/disable EFS backup policy