### PR TITLE
Adding EFS arn in the resource of IAM policy to fix the diff

### DIFF
--- a/efs.tf
+++ b/efs.tf
@@ -82,6 +82,7 @@ data "aws_iam_policy_document" "efs_file_system_policy" {
       values   = ["true"]
       variable = "elasticfilesystem:AccessedViaMountTarget"
     }
+    resources = [module.efs.arn]
   }
 }
 


### PR DESCRIPTION
A diff is always coming like this because the data block doesn't have the file system ARN
```
  # module.efs.aws_efs_file_system_policy.this will be updated in-place
  ~ resource "aws_efs_file_system_policy" "this" {
        id                                 = "fs-ID"
      ~ policy                             = jsonencode(
          ~ {
              ~ Statement = [
                  ~ {
                      ~ Resource  = "arn:aws:elasticfilesystem:us-east-1:ACCID:file-system/fs-ID" 
                        # (4 unchanged attributes hidden)
                    },
                ]
                # (1 unchanged attribute hidden)
            }
        )
        # (2 unchanged attributes hidden)
    }
```
Adding the EFS arn in the data block removes the diff.