### PR TITLE
Switch to AWS managed EFS CSI Driver policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,6 @@ Truefoundry AWS EFS Module
 | Name | Type |
 |------|------|
 | [aws_efs_file_system_policy.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/efs_file_system_policy) | resource |
-| [aws_iam_policy.efs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
-| [aws_iam_policy_document.efs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.efs_file_system_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 
 ## Inputs

--- a/efs.tf
+++ b/efs.tf
@@ -1,72 +1,7 @@
-resource "aws_iam_policy" "efs" {
-  count       = var.create_efs_iam_role && var.create_efs_access_policy ? 1 : 0
-  name_prefix = local.efs_access_policy_prefix
-  description = "EFS Access policy for cluster"
-  policy      = data.aws_iam_policy_document.efs.json
-  tags        = local.tags
-}
-
 resource "aws_efs_file_system_policy" "this" {
   file_system_id                     = module.efs.id
   bypass_policy_lockout_safety_check = false
   policy                             = data.aws_iam_policy_document.efs_file_system_policy.json
-}
-
-
-# https://github.com/kubernetes-sigs/aws-efs-csi-driver/blob/master/docs/iam-policy-example.json
-data "aws_iam_policy_document" "efs" {
-  statement {
-    effect = "Allow"
-    actions = [
-      "elasticfilesystem:DescribeAccessPoints",
-      "elasticfilesystem:DescribeFileSystems",
-      "elasticfilesystem:DescribeMountTargets",
-      "ec2:DescribeAvailabilityZones"
-    ]
-    resources = ["*"]
-  }
-  statement {
-    effect = "Allow"
-    actions = [
-      "elasticfilesystem:DeleteAccessPoint"
-    ]
-    resources = [
-      "*"
-    ]
-    condition {
-      test     = "StringEquals"
-      values   = ["true"]
-      variable = "aws:ResourceTag/efs.csi.aws.com/cluster"
-    }
-  }
-  statement {
-    effect = "Allow"
-    actions = [
-      "elasticfilesystem:TagResource"
-    ]
-    resources = [
-      "*"
-    ]
-    condition {
-      test     = "StringLike"
-      values   = ["true"]
-      variable = "aws:ResourceTag/efs.csi.aws.com/cluster"
-    }
-  }
-  statement {
-    effect = "Allow"
-    actions = [
-      "elasticfilesystem:CreateAccessPoint",
-    ]
-    resources = [
-      "*"
-    ]
-    condition {
-      test     = "StringLike"
-      values   = ["true"]
-      variable = "aws:RequestTag/efs.csi.aws.com/cluster"
-    }
-  }
 }
 
 # EFS file system policy

--- a/iam-sa.tf
+++ b/iam-sa.tf
@@ -13,7 +13,7 @@ module "iam_assumable_role_admin" {
   role_permissions_boundary_arn = var.efs_iam_role_permissions_boundary_arn
 
   role_policy_arns = concat([
-    var.create_efs_access_policy ? aws_iam_policy.efs[0].arn : var.existing_efs_access_policy_arn
+    var.create_efs_access_policy ? "arn:aws:iam::aws:policy/service-role/AmazonEFSCSIDriverPolicy" : var.existing_efs_access_policy_arn
     ],
     var.efs_iam_role_additional_policy_arns
   )


### PR DESCRIPTION
- Replaces the custom EFS IAM policy with the AWS managed policy 'AmazonEFSCSIDriverPolicy' and removes the custom policy resource and document.

Test Plan
- [x] apply to test cluster; grep efs-csi-driver deployment/ds logs for errors