### PR TITLE
Adding option to override EFS policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Truefoundry AWS EFS Module
 | <a name="input_cluster_name"></a> [cluster\_name](#input\_cluster\_name) | EKS Cluster Name | `string` | n/a | yes |
 | <a name="input_cluster_oidc_issuer_arn"></a> [cluster\_oidc\_issuer\_arn](#input\_cluster\_oidc\_issuer\_arn) | The oidc issuer arn of the eks cluster | `string` | n/a | yes |
 | <a name="input_create_efs_access_policy"></a> [create\_efs\_access\_policy](#input\_create\_efs\_access\_policy) | Enable/disable creation of EFS access policy | `bool` | `true` | no |
+| <a name="input_create_efs_file_system_policy"></a> [create\_efs\_file\_system\_policy](#input\_create\_efs\_file\_system\_policy) | Enable/disable creation of EFS file system policy | `bool` | `true` | no |
 | <a name="input_create_efs_iam_role"></a> [create\_efs\_iam\_role](#input\_create\_efs\_iam\_role) | Enable/disable creation of IAM role for EFS | `bool` | `true` | no |
 | <a name="input_disable_default_tags"></a> [disable\_default\_tags](#input\_disable\_default\_tags) | Disable the default tag for the EFSs. Used in cases where only certain tags are allowed | `bool` | `false` | no |
 | <a name="input_efs_access_policy_prefix_enable_override"></a> [efs\_access\_policy\_prefix\_enable\_override](#input\_efs\_access\_policy\_prefix\_enable\_override) | Enable/disable override of the EFS access policy. When enabled, the EFS access policy will be set to the value of efs\_access\_policy\_prefix\_override\_name | `bool` | `false` | no |

--- a/efs.tf
+++ b/efs.tf
@@ -7,6 +7,7 @@ resource "aws_iam_policy" "efs" {
 }
 
 resource "aws_efs_file_system_policy" "this" {
+  count                              = var.create_efs_file_system_policy ? 1 : 0
   file_system_id                     = module.efs.id
   bypass_policy_lockout_safety_check = false
   policy                             = data.aws_iam_policy_document.efs_file_system_policy.json
@@ -124,4 +125,9 @@ module "efs" {
 moved {
   from = aws_iam_policy.efs
   to   = aws_iam_policy.efs[0]
+}
+
+moved {
+  from = aws_efs_file_system_policy.this
+  to   = aws_efs_file_system_policy.this[0]
 }

--- a/variables.tf
+++ b/variables.tf
@@ -137,6 +137,13 @@ variable "performance_mode" {
   }
 }
 
+
+variable "create_efs_file_system_policy" {
+  description = "Enable/disable creation of EFS file system policy"
+  type        = bool
+  default     = true
+}
+
 variable "enable_backup_policy" {
   description = "Enable EFS backup policy"
   type        = bool


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds a new toggle that can skip creating `aws_efs_file_system_policy`, which can change EFS access enforcement and may cause unexpected diffs/destroys if toggled in existing deployments.
> 
> **Overview**
> Adds **optional creation** for the EFS file system policy via new input `create_efs_file_system_policy` (default `true`) and wires it into `aws_efs_file_system_policy.this` using `count`.
> 
> Includes a Terraform `moved` block to migrate the file system policy resource address to indexed form (`aws_efs_file_system_policy.this[0]`) and updates the README inputs table accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b18f6c925723a2b062f78d22cd5b623445e35311. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->