### PR TITLE
fix: relax aws provider constraint to ~> 6.33

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,13 +7,13 @@ Truefoundry AWS EFS Module
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | ~> 1.4 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 6.33.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 6.33 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 6.33.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 6.33 |
 
 ## Modules
 

--- a/versions.tf
+++ b/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.33.0"
+      version = "~> 6.33"
     }
   }
 }


### PR DESCRIPTION
## What

Relax the `aws` provider constraint in `versions.tf` from `~> 6.33.0` → `~> 6.33`.

```diff
-      version = "~> 6.33.0"
+      version = "~> 6.33"
```

## Why

`~> 6.33.0` pins to **6.33.x** (`>= 6.33.0, < 6.34.0`). Every sibling `truefoundry-*` AWS wrapper (network, cluster, load-balancer-controller, platform-features) uses the looser `~> 6.33` (`< 7.0`) — this module was the lone outlier. The tight form was introduced in #22 (v5→v6 provider migration) and looks like an inadvertent `.0`, since the prior form was `~> 5.57` (minor-level).

It stayed latent until **`terraform-aws-modules/eks` 21.22.0** was published on **2026-05-25**, which raised its requirement to `aws >= 6.42`. The `truefoundry/truefoundry-platform` template pulls that eks module transitively via `truefoundry-karpenter`'s `~> 21.0` float, and rendered configs run a fresh `tofu init` with no committed lockfile — so the new release floated in automatically.

`6.33.x` ∩ `>= 6.42` = ∅, so AWS platform deploys began failing at init with:

```
Could not resolve provider hashicorp/aws: no available releases match the given
constraints >= ... ~> 6.33.0 ... >= 6.42.0
```

**No change on our side caused this** — the same code worked ~2 days earlier. Relaxing to `~> 6.33` matches the sibling wrappers, accepts `6.42+`, and resolves the conflict.

## Note

The `truefoundry-platform` template is temporarily pinned to this branch via a `git::` source to unblock deploys; it will revert to the registry source and pin the new release once this merges and is tagged.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and provider constraint only; no infrastructure or application logic is modified.
> 
> **Overview**
> Relaxes the **hashicorp/aws** provider version in `versions.tf` from **`~> 6.33.0`** (6.33.x only) to **`~> 6.33`** (any 6.x ≥ 6.33, below 7.0), aligning this module with other Truefoundry AWS wrappers.
> 
> The generated **README** requirements/providers tables are updated to match. No EFS, IAM, or module behavior changes—only provider resolution during `terraform init` / `tofu init`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 77ccc469da60bfc26101930446d55c780adac190. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->